### PR TITLE
Add regex tests for openconfig-yang-types.yang

### DIFF
--- a/testdata/regexp-test.yang
+++ b/testdata/regexp-test.yang
@@ -58,11 +58,13 @@ module regexp-test {
     pt:pattern-test-pass "2006-12-20T00:39:57Z";
     pt:pattern-test-pass "1937-01-01T12:00:27.87+00:20";
     // Out of range tests.
+    pt:pattern-test-fail "0000-00-01T00:00:00Z";
     pt:pattern-test-fail "0000-13-01T00:00:00Z";
     pt:pattern-test-fail "0000-20-01T00:00:00Z";
+    pt:pattern-test-fail "0000-01-00T00:00:00Z";
     pt:pattern-test-fail "0000-01-32T00:00:00Z";
     pt:pattern-test-fail "0000-01-40T00:00:00Z";
-    pt:pattern-test-fail "0000-01-01T25:00:00Z";
+    pt:pattern-test-fail "0000-01-01T24:00:00Z";
     pt:pattern-test-fail "0000-01-01T30:00:00Z";
     pt:pattern-test-fail "0000-01-01T00:60:00Z";
     pt:pattern-test-fail "0000-01-01T00:00:61Z";
@@ -70,13 +72,13 @@ module regexp-test {
     // + tests.
     pt:pattern-test-fail "0000-01-01T00:00:00Z+";
     pt:pattern-test-pass "0000-01-01T00:00:00+00:00";
-    pt:pattern-test-fail "0000-01-01T00:00:00+25:00";
+    pt:pattern-test-fail "0000-01-01T00:00:00+24:00";
     pt:pattern-test-fail "0000-01-01T00:00:00+30:00";
     pt:pattern-test-fail "0000-01-01T00:00:00+00:60";
     // - tests.
     pt:pattern-test-fail "0000-01-01T00:00:00Z-";
     pt:pattern-test-pass "0000-01-01T00:00:00-00:00";
-    pt:pattern-test-fail "0000-01-01T00:00:00-25:00";
+    pt:pattern-test-fail "0000-01-01T00:00:00-24:00";
     pt:pattern-test-fail "0000-01-01T00:00:00-30:00";
     pt:pattern-test-fail "0000-01-01T00:00:00-00:60";
     // Leap second tests.
@@ -95,6 +97,8 @@ module regexp-test {
     pt:pattern-test-pass "2006-12-20";
     pt:pattern-test-pass "1937-01-01";
     // Out of range tests.
+    pt:pattern-test-fail "0000-00-01";
+    pt:pattern-test-fail "0000-01-00";
     pt:pattern-test-fail "0000-13-01";
     pt:pattern-test-fail "0000-20-01";
     pt:pattern-test-fail "0000-33-01";


### PR DESCRIPTION
Tests for both posix-pattern and XSD patterns all pass on https://github.com/openconfig/models/pull/920.

**NOTE**: Failures are expected in the demo runs on openconfig/public since the patterns themselves are being changed/fixed.

Demo openconfig/public output on `posix-pattern` (this table will be automatically posted for both posix-pattern and pattern once #11 is merged:

| leaf | typedef | error |
| --- | --- | --- |
| `date-and-time` | `date-and-time` | `0000-01-01T00:00:00Z` did not match |
| `date-and-time` | `date-and-time` | `9999-12-31T23:59:59Z` did not match |
| `date-and-time` | `date-and-time` | `1985-04-12T23:20:50.52Z` did not match |
| `date-and-time` | `date-and-time` | `2001-04-12T23:20:50.42424242Z` did not match |
| `date-and-time` | `date-and-time` | `1996-12-19T16:39:57-08:00` did not match |
| `date-and-time` | `date-and-time` | `2006-12-20T00:39:57Z` did not match |
| `date-and-time` | `date-and-time` | `1937-01-01T12:00:27.87+00:20` did not match |
| `date-and-time` | `date-and-time` | `0000-01-01T00:00:00+00:00` did not match |
| `date-and-time` | `date-and-time` | `0000-01-01T00:00:00-00:00` did not match |
| `date-and-time` | `date-and-time` | `1990-12-31T23:59:60Z` did not match |
| `date-and-time` | `date-and-time` | `1990-12-31T15:59:60-08:00` did not match |
| `date` | `date` | `0000-00-01` matched but shouldn't |
| `date` | `date` | `0000-01-00` matched but shouldn't |
| `date` | `date` | `0000-13-01` matched but shouldn't |
| `date` | `date` | `0000-20-01` matched but shouldn't |
| `date` | `date` | `0000-33-01` matched but shouldn't |
| `date` | `date` | `0000-01-32` matched but shouldn't |
| `date` | `date` | `0000-01-40` matched but shouldn't |

All XSD tests fail since the tests currently have anchors.