### PR TITLE
Require test on openconfig/public to pass

### DIFF
--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -60,6 +60,6 @@ jobs:
 
     - name: Demo output on openconfig/public
       run: |
-          find "$OCDIR/regexp-tests" -name "*.yang" -print0 | xargs -0 go run gotests/main.go -model-root ~/tmp/public
+          find "$OCDIR/regexp-tests" -name "*.yang" -print0 | xargs -0 go run gotests/main.go -model-root "$OCDIR"
       env:
           OCDIR: /tmp/public


### PR DESCRIPTION
Now that the regex tests are in sync with the models they test, we can now require changes to this repo to always show a passing regex test result.

Fixes #14 